### PR TITLE
fixing bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "angular-resource": "~1.2.14",
     "angular-route": "~1.2.14",
     "angular-toggle-switch": "~0.3.0",
-    "angular-bootstrap-toggle-switch": "~0.5.1",
+    "angular-bootstrap-toggle-switch": "0.5.2",
     "angular-bootstrap": "~0.11.0",
     "bootstrap-social": "~4.6.0",
     "font-awesome": "~4.1.0",


### PR DESCRIPTION
`angular-bootstrap-toggle-switch` breaks hobknob's toggles on version `0.5.3` and `0.5.4`.