### PR TITLE
Fixing rendering issue due to changes to google oauth

### DIFF
--- a/client/js/domain/user.js
+++ b/client/js/domain/user.js
@@ -25,7 +25,7 @@ angular.module('featureToggleFrontend')
             },
 
             getFullName: function () {
-                return this.name || 'Anonymous';
+                return this.name.givenName + ' ' + this.name.familyName || 'Anonymous';
             },
 
             requiresAuthentication: function () {


### PR DESCRIPTION
Looks like there might be a change to the way that google oauth returns data. Previously this.name returned the users full name and now returns an object made up of the users givenName and familyName. This fix concatenates them so the user sees their full name as it was shown previously.

<img width="277" alt="screen shot 2016-07-05 at 5 42 41 pm" src="https://cloud.githubusercontent.com/assets/1033384/16592297/f471987c-42d7-11e6-81ad-9dc59aeeec46.png">
