### PR TITLE
Feature hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ config/config.json:
 }
 ```
 
+## Feature hooks
+You can add custom hooks that will run for feature-events (add, delete, update), E.g. reporting toggle events to slack, hipchat etc.
+
+The hooks must follow the interface specified [here](server/exampleHook.js). The function signature is `function(eventInfo, next){}` where `next` is a callback taking one argument (an error).
+
+Register your hooks by adding them to the `hooks` array in the configuration file:
+
+```
+  "hooks": [
+    "server/exampleHook.js"
+  ]
+```
+
 ## Hobknob Clients
 There are several clients for different languages.
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ config/config.json:
 ## Feature hooks
 You can add custom hooks that will run for feature-events (add, delete, update), E.g. reporting toggle events to slack, hipchat etc.
 
-The hooks must follow the interface specified [here](server/exampleHook.js). The function signature is `function(eventInfo, next){}` where `next` is a callback taking one argument (an error).
+The hooks can implement any or all of the interface methods specified [here](server/exampleHook.js). The function signature is `function(eventInfo, next){}` where `next` is a callback taking one argument (an error).
 
 Register your hooks by adding them to the `hooks` array in the configuration file:
 

--- a/config/config.json
+++ b/config/config.json
@@ -35,5 +35,8 @@
     ],
     "plugin": {
         "path": "../server/examplePlugin.js"
-    }
+    },
+    "hooks": [
+      "server/exampleHook.js"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/opentable/hobknob/issues"
   },
   "dependencies": {
+    "async": "^2.0.0-rc.6",
     "body-parser": "^1.14.0",
     "config": "^1.16.0",
     "express": "~3.4.8",

--- a/server/audit.js
+++ b/server/audit.js
@@ -5,10 +5,6 @@ var _ = require('underscore');
 var config = require('./../config/config.json');
 var replicationHook = require('./src/hooks/auditReplication');
 
-var getUserDetails = function (req) {
-    return config.RequiresAuth ? req.user._json : {name: 'Anonymous'};
-};
-
 module.exports = {
     getApplicationAuditTrail: function (applicationName, callback) {
         var path = 'v1/audit/application/' + applicationName;
@@ -44,9 +40,9 @@ module.exports = {
         });
     },
 
-    addApplicationAudit: function (req, applicationName, action, callback) {
+    addApplicationAudit: function (user, applicationName, action, callback) {
         var audit = {
-            user: getUserDetails(req),
+            user: user,
             action: action,
             dateModified: new Date().toISOString() // todo: should be UTC time
         };
@@ -74,9 +70,9 @@ module.exports = {
         });
     },
 
-    addFeatureAudit: function (req, applicationName, featureName, toggleName, value, action, callback) {
+    addFeatureAudit: function (user, applicationName, featureName, toggleName, value, action, callback) {
         var audit = {
-            user: getUserDetails(req),
+            user: user,
             toggleName: toggleName,
             value: value,
             action: action,

--- a/server/domain/application.js
+++ b/server/domain/application.js
@@ -66,7 +66,7 @@ module.exports = {
                 return cb(err);
             }
 
-            audit.addApplicationAudit(req, applicationName, 'Deleted', function () {
+            audit.addApplicationAudit(getUserDetails(req), applicationName, 'Deleted', function () {
                 if (err) {
                     console.log(err);
                 }

--- a/server/domain/application.js
+++ b/server/domain/application.js
@@ -7,6 +7,10 @@ var acl = require('./../acl');
 var audit = require('./../audit');
 var etcdBaseUrl = 'http://' + config.etcdHost + ':' + config.etcdPort + '/v2/keys/';
 
+var getUserDetails = function (req) {
+    return config.RequiresAuth ? req.user._json : {name: 'Anonymous'};
+};
+
 module.exports = {
     getApplications: function (cb) {
         etcd.client.get('v1/toggles/', {recursive: false}, function (err, result) {
@@ -33,7 +37,7 @@ module.exports = {
                 return cb(err);
             }
 
-            audit.addApplicationAudit(req, applicationName, 'Created', function () {
+            audit.addApplicationAudit(getUserDetails(req), applicationName, 'Created', function () {
                 if (err) {
                     console.log(err); // todo: better logging
                 }
@@ -41,7 +45,7 @@ module.exports = {
 
             // todo: not sure if this is correct
             if (config.RequiresAuth) {
-                var userEmail = req.user._json.email;
+                var userEmail = getUserDetails(req).email; // todo: need better user management
                 acl.grant(userEmail, applicationName, function (grantErr) {
                     if (grantErr) {
                         cb(grantErr);

--- a/server/exampleHook.js
+++ b/server/exampleHook.js
@@ -1,0 +1,59 @@
+'use strict';
+
+module.exports = {
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+  }
+  */
+  addFeature: function(featureEvent, next){
+    next();
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+  }
+  */
+  deleteFeature: function(featureEvent, next){
+    next();
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle',
+    value: false
+  }
+  */
+  addFeatureToggle: function(toggleEvent, next){
+    next();
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle',
+    value: false
+  }
+  */
+  updateFeatureToggle: function(updateEvent, next){
+    next();
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle'
+  }
+  */
+  deleteFeatureToggle: function(deleteEvent, next){
+    next();
+  }
+};

--- a/server/exampleHook.js
+++ b/server/exampleHook.js
@@ -8,7 +8,7 @@ module.exports = {
     featureName: 'my-feature',
   }
   */
-  addFeature: function(featureEvent, next){
+  addFeature: function(featureEvent, next) {
     next();
   },
   /*
@@ -18,19 +18,7 @@ module.exports = {
     featureName: 'my-feature',
   }
   */
-  deleteFeature: function(featureEvent, next){
-    next();
-  },
-  /*
-  {
-    user: { name: 'anonymous' },
-    applicationName: 'my-app',
-    featureName: 'my-feature',
-    toggleName: 'my-toggle',
-    value: false
-  }
-  */
-  addFeatureToggle: function(toggleEvent, next){
+  deleteFeature: function(featureEvent, next) {
     next();
   },
   /*
@@ -42,7 +30,19 @@ module.exports = {
     value: false
   }
   */
-  updateFeatureToggle: function(updateEvent, next){
+  addFeatureToggle: function(toggleEvent, next) {
+    next();
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle',
+    value: false
+  }
+  */
+  updateFeatureToggle: function(updateEvent, next) {
     next();
   },
   /*
@@ -53,7 +53,7 @@ module.exports = {
     toggleName: 'my-toggle'
   }
   */
-  deleteFeatureToggle: function(deleteEvent, next){
+  deleteFeatureToggle: function(deleteEvent, next) {
     next();
   }
 };

--- a/server/src/hooks/audit.js
+++ b/server/src/hooks/audit.js
@@ -1,0 +1,99 @@
+var audit = require('../../audit');
+
+module.exports = {
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+  }
+  */
+  addFeature: function(featureEvent, next){
+    audit.addFeatureAudit(
+      featureEvent.user,
+      featureEvent.applicationName,
+      featureEvent.featureName,
+      null,
+      null,
+      'Feature Created', function (err) {
+        next(err);
+    });
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+  }
+  */
+  deleteFeature: function(featureEvent, next){
+    audit.addFeatureAudit(
+      featureEvent.user,
+      featureEvent.applicationName,
+      featureEvent.featureName,
+      null,
+      null,
+      'Deleted', function (err) {
+        next(err);
+    });
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle',
+    value: false
+  }
+  */
+  addFeatureToggle: function(toggleEvent, next){
+    audit.addFeatureAudit(
+      toggleEvent.user,
+      toggleEvent.applicationName,
+      toggleEvent.featureName,
+      toggleEvent.toggleName,
+      toggleEvent.value,
+      'Toggle Created', function (err) {
+        next(err);
+    });
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle',
+    value: false
+  }
+  */
+  updateFeatureToggle: function(updateEvent, next){
+    audit.addFeatureAudit(
+      updateEvent.user,
+      updateEvent.applicationName,
+      updateEvent.featureName,
+      updateEvent.toggleName,
+      updateEvent.value,
+      'Updated', function (err) {
+        next(err);
+    });
+  },
+  /*
+  {
+    user: { name: 'anonymous' },
+    applicationName: 'my-app',
+    featureName: 'my-feature',
+    toggleName: 'my-toggle'
+  }
+  */
+  deleteFeatureToggle: function(deleteEvent, next){
+    audit.addFeatureAudit(
+      deleteEvent.user,
+      deleteEvent.applicationName,
+      deleteEvent.featureName,
+      deleteEvent.toggleName,
+      null,
+      'Deleted', function (err) {
+        next(err);
+    });
+  }
+};

--- a/server/src/hooks/audit.js
+++ b/server/src/hooks/audit.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var audit = require('../../audit');
 
 module.exports = {
@@ -8,16 +10,14 @@ module.exports = {
     featureName: 'my-feature',
   }
   */
-  addFeature: function(featureEvent, next){
+  addFeature: function (featureEvent, next) {
     audit.addFeatureAudit(
       featureEvent.user,
       featureEvent.applicationName,
       featureEvent.featureName,
       null,
       null,
-      'Feature Created', function (err) {
-        next(err);
-    });
+      'Feature Created', next);
   },
   /*
   {
@@ -26,16 +26,14 @@ module.exports = {
     featureName: 'my-feature',
   }
   */
-  deleteFeature: function(featureEvent, next){
+  deleteFeature: function (featureEvent, next) {
     audit.addFeatureAudit(
       featureEvent.user,
       featureEvent.applicationName,
       featureEvent.featureName,
       null,
       null,
-      'Deleted', function (err) {
-        next(err);
-    });
+      'Deleted', next);
   },
   /*
   {
@@ -46,16 +44,14 @@ module.exports = {
     value: false
   }
   */
-  addFeatureToggle: function(toggleEvent, next){
+  addFeatureToggle: function (toggleEvent, next) {
     audit.addFeatureAudit(
       toggleEvent.user,
       toggleEvent.applicationName,
       toggleEvent.featureName,
       toggleEvent.toggleName,
       toggleEvent.value,
-      'Toggle Created', function (err) {
-        next(err);
-    });
+      'Toggle Created', next);
   },
   /*
   {
@@ -66,16 +62,14 @@ module.exports = {
     value: false
   }
   */
-  updateFeatureToggle: function(updateEvent, next){
+  updateFeatureToggle: function (updateEvent, next) {
     audit.addFeatureAudit(
       updateEvent.user,
       updateEvent.applicationName,
       updateEvent.featureName,
       updateEvent.toggleName,
       updateEvent.value,
-      'Updated', function (err) {
-        next(err);
-    });
+      'Updated', next);
   },
   /*
   {
@@ -85,15 +79,13 @@ module.exports = {
     toggleName: 'my-toggle'
   }
   */
-  deleteFeatureToggle: function(deleteEvent, next){
+  deleteFeatureToggle: function (deleteEvent, next) {
     audit.addFeatureAudit(
       deleteEvent.user,
       deleteEvent.applicationName,
       deleteEvent.featureName,
       deleteEvent.toggleName,
       null,
-      'Deleted', function (err) {
-        next(err);
-    });
+      'Deleted', next);
   }
 };

--- a/server/src/hooks/featureHooks.js
+++ b/server/src/hooks/featureHooks.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path');
 var async = require('async');
 var TIMEOUT = 5 * 1000;
@@ -8,25 +10,25 @@ var builtInHooks = [
 ];
 var customHooks = config.hooks || [];
 
-var hooks = builtInHooks.concat(customHooks).map(function(hook){
+var hooks = builtInHooks.concat(customHooks).map(function (hook) {
   var hookpath = path.resolve(hook);
   try {
     return require(hookpath);
   }
-  catch(error){
+  catch (error) {
     console.log('Error loading hook: ' + hookpath);
   }
 });
 
-module.exports.run = function(ev){
-  async.each(hooks, function(hook, done){
-    if(hook[ev.fn]){
+module.exports.run = function (ev) {
+  async.each(hooks, function (hook, done) {
+    if (hook[ev.fn]) {
       var fn = async.timeout(hook[ev.fn], TIMEOUT);
       return fn(ev, done);
     }
     done();
-  }, function(err){
-    if(err){
+  }, function(err) {
+    if (err) {
       console.log(err);
     }
   });

--- a/server/src/hooks/featureHooks.js
+++ b/server/src/hooks/featureHooks.js
@@ -1,0 +1,32 @@
+var path = require('path');
+var async = require('async');
+
+var config = require('../../../config/config.json');
+var builtInHooks = [
+  './server/src/hooks/audit.js',
+  //'./server/src/hooks/auditReplication.js'
+];
+var customHooks = config.hooks || [];
+
+var hooks = builtInHooks.concat(customHooks).map(function(hook){
+  var hookpath = path.resolve(hook);
+  try {
+    return require(hookpath);
+  }
+  catch(error){
+    console.log('Error loading hook: ' + hookpath);
+  }
+});
+
+module.exports.run = function(ev){
+  async.each(hooks, function(hook, done){
+    if(hook[ev.fn]){
+      return hook[ev.fn](ev, done);
+    }
+    done();
+  }, function(err){
+    if(err){
+      console.log(err);
+    }
+  });
+};

--- a/server/src/hooks/featureHooks.js
+++ b/server/src/hooks/featureHooks.js
@@ -1,10 +1,10 @@
 var path = require('path');
 var async = require('async');
+var TIMEOUT = 5 * 1000;
 
 var config = require('../../../config/config.json');
 var builtInHooks = [
-  './server/src/hooks/audit.js',
-  //'./server/src/hooks/auditReplication.js'
+  './server/src/hooks/audit.js'
 ];
 var customHooks = config.hooks || [];
 
@@ -21,7 +21,8 @@ var hooks = builtInHooks.concat(customHooks).map(function(hook){
 module.exports.run = function(ev){
   async.each(hooks, function(hook, done){
     if(hook[ev.fn]){
-      return hook[ev.fn](ev, done);
+      var fn = async.timeout(hook[ev.fn], TIMEOUT);
+      return fn(ev, done);
     }
     done();
   }, function(err){


### PR DESCRIPTION
add custom 'feature-hooks' to run arbitrary code when feature events happen (add, update, delete).

Slightly tramples on the (auditReplication)[https://github.com/opentable/hobknob/issues/159] feature but basically reimplements it in a more flexible way (and then some).

The major change is that auditing is now a feature-hook itself.