### PR TITLE
lowercase the email before inserting the acl entry

### DIFF
--- a/server/domain/application.js
+++ b/server/domain/application.js
@@ -45,7 +45,7 @@ module.exports = {
 
             // todo: not sure if this is correct
             if (config.RequiresAuth) {
-                var userEmail = getUserDetails(req).getEmail(); // todo: need better user management
+                var userEmail = getUserDetails(req).email.toLowerCase(); // todo: need better user management
                 acl.grant(userEmail, applicationName, function (grantErr) {
                     if (grantErr) {
                         cb(grantErr);


### PR DESCRIPTION
the `.getEmail()` method doesn't exist server-side, so for now just lowercase the email