### PR TITLE
Refactoring the Imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,7 @@
    - Additional backends are now supported - made possible by refactoring & wrapping the etcD support
  - Changed:
    - Add a failure flash when Azure gives you Auth problems to match the Google Auth experience
+ - Refactoring:
+   - Updated the imports to reference the root path - making refactoring simpler (things like `require('../../../config')` are now `require(__base + '/')`)
 
 ---

--- a/server/app.js
+++ b/server/app.js
@@ -1,18 +1,19 @@
 'use strict';
+global.__base = __dirname;
 
 var express = require('express');
 var app = express();
 var bodyParser = require('body-parser');
-var dashboardRoutes = require('./routes/dashboardRoutes');
-var loadBalancerRoutes = require('./routes/loadbalancerRoutes');
-var authenticateRoutes = require('./routes/authenticateRoutes');
-var authorisationRoutes = require('./routes/authorisationRoutes');
-var auditRoutes = require('./routes/auditRoutes');
-var applicationRoutes = require('./routes/applicationRoutes');
-var featureRoutes = require('./routes/featureRoutes');
+var dashboardRoutes = require(__base + '/routes/dashboardRoutes');
+var loadBalancerRoutes = require(__base + '/routes/loadbalancerRoutes');
+var authenticateRoutes = require(__base + '/routes/authenticateRoutes');
+var authorisationRoutes = require(__base + '/routes/authorisationRoutes');
+var auditRoutes = require(__base + '/routes/auditRoutes');
+var applicationRoutes = require(__base + '/routes/applicationRoutes');
+var featureRoutes = require(__base + '/routes/featureRoutes');
 var path = require('path');
 var acl = require('./domain/acl');
-var config = require('./../config/config.json');
+var config = require(__base + '/../config/config.json');
 var _ = require('underscore');
 var passport = require('./auth').init(config);
 

--- a/server/domain/acl.js
+++ b/server/domain/acl.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var config = require('./../../config/config.json');
+var config = require(__base + '/../config/config.json');
 var acl = function() {
   switch (config.dataSource.toLowerCase()) {
     case 'etcd':
-      return require('./etcd/acl');
+      return require(__base + '/domain/etcd/acl');
 
     default:
       return null;

--- a/server/domain/application.js
+++ b/server/domain/application.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var config = require('./../../config/config.json');
+var config = require(__base + '/../config/config.json');
 var application = function() {
   switch (config.dataSource.toLowerCase()) {
     case 'etcd':
-      return require('./etcd/application');
+      return require(__base + '/domain/etcd/application');
 
     default:
       return null;

--- a/server/domain/audit.js
+++ b/server/domain/audit.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var config = require('./../../config/config.json');
+var config = require(__base + '/../config/config.json');
 var audit = function() {
   switch (config.dataSource.toLowerCase()) {
     case 'etcd':
-      return require('./etcd/audit');
+      return require(__base + '/domain/etcd/audit');
 
     default:
       return null;

--- a/server/domain/category.js
+++ b/server/domain/category.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var _ = require('underscore');
-var config = require('./../../config/config.json');
-var acl = require('./acl');
-var audit = require('./audit');
+var config = require(__base + '/../config/config.json');
+var acl = require(__base + '/domain/acl');
+var audit = require(__base + '/domain/audit');
 
 var getCategory = function (id, name, description, columns, features) {
     return {

--- a/server/domain/etcd/acl.js
+++ b/server/domain/etcd/acl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var etcd = require('./etcd');
+var etcd = require(__base + '/domain/etcd/etcd');
 var _ = require('underscore');
 
 var EtcdAclStore = function () {

--- a/server/domain/etcd/application.js
+++ b/server/domain/etcd/application.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var etcd = require('./etcd');
+var etcd = require(__base + '/domain/etcd/etcd');
 var _ = require('underscore');
-var config = require('./../../../config/config.json');
-var acl = require('./../acl');
-var audit = require('./../audit');
+var config = require(__base + '/../config/config.json');
+var acl = require(__base + '/domain/acl');
+var audit = require(__base + '/domain/audit');
 var etcdBaseUrl = 'http://' + config.etcdHost + ':' + config.etcdPort + '/v2/keys/';
 
 var getUserDetails = function (req) {

--- a/server/domain/etcd/audit.js
+++ b/server/domain/etcd/audit.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var etcd = require('./etcd');
+var etcd = require(__base + '/domain/etcd/etcd');
 var _ = require('underscore');
-var config = require('./../../../config/config.json');
+var config = require(__base + '/../config/config.json');
 
 module.exports = {
     getApplicationAuditTrail: function (applicationName, callback) {

--- a/server/domain/etcd/etcd.js
+++ b/server/domain/etcd/etcd.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var config = require('./../../../config/config.json');
+var config = require(__base + '/../config/config.json');
 var Etcd = require('node-etcd');
 
 module.exports.client = new Etcd(config.etcdHost, config.etcdPort);

--- a/server/domain/etcd/feature.js
+++ b/server/domain/etcd/feature.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var etcd = require('./etcd');
+var etcd = require(__base + '/domain/etcd/etcd');
 var _ = require('underscore');
-var config = require('./../../../config/config.json');
-var acl = require('./../acl');
-var category = require('./../category');
+var config = require(__base + '/../config/config.json');
+var acl = require(__base + '/domain/acl');
+var category = require(__base + '/domain/category');
 var etcdBaseUrl = 'http://' + config.etcdHost + ':' + config.etcdPort + '/v2/keys/';
 var s = require('string');
-var hooks = require('../../src/hooks/featureHooks');
+var hooks = require(__base + '/src/hooks/featureHooks');
 
 var isMetaNode = function (node) {
     return s(node.key).endsWith('@meta');

--- a/server/domain/feature.js
+++ b/server/domain/feature.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var config = require('./../../config/config.json');
+var config = require(__base + '/../config/config.json');
 var feature = function() {
   switch (config.dataSource.toLowerCase()) {
     case 'etcd':
-      return require('./etcd/feature');
+      return require(__base + '/domain/etcd/feature');
 
     default:
       return null;

--- a/server/routes/applicationRoutes.js
+++ b/server/routes/applicationRoutes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var application = require('./../domain/application');
+var application = require(__base + '/domain/application');
 
 var getApplications = function (req, res) {
     application.getApplications(

--- a/server/routes/auditRoutes.js
+++ b/server/routes/auditRoutes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var audit = require('./../domain/audit');
+var audit = require(__base + '/domain/audit');
 
 module.exports = {
     getFeatureAuditTrail: function (req, res) {

--- a/server/routes/authorisationRoutes.js
+++ b/server/routes/authorisationRoutes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
-var acl = require('../domain/acl');
+var acl = require(__base + '/domain/acl');
 var validator = require('validator');
 
 module.exports = {

--- a/server/routes/dashboardRoutes.js
+++ b/server/routes/dashboardRoutes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var config = require('./../../config/config.json');
+var config = require(__base + '/../config/config.json');
 
 exports.dashboard = function (req, res) {
     res.render('main',

--- a/server/routes/featureRoutes.js
+++ b/server/routes/featureRoutes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var feature = require('./../domain/feature');
+var feature = require(__base + '/domain/feature');
 
 var getFeatureCategories = function (req, res) {
     feature.getFeatureCategories(req.params.applicationName,

--- a/server/routes/loadbalancerRoutes.js
+++ b/server/routes/loadbalancerRoutes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var config = require('../../config/config.json');
+var config = require(__base + '/../config/config.json');
 
 exports.lbstatus = function (req, res) {
     var filePath = config.loadBalancerFile;

--- a/server/src/hooks/audit.js
+++ b/server/src/hooks/audit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var audit = require('../../domain/audit');
+var audit = require(__base + '/domain/audit');
 
 module.exports = {
   /*

--- a/server/src/hooks/featureHooks.js
+++ b/server/src/hooks/featureHooks.js
@@ -4,7 +4,7 @@ var path = require('path');
 var async = require('async');
 var TIMEOUT = 5 * 1000;
 
-var config = require('../../../config/config.json');
+var config = require(__base + '/../config/config.json');
 var builtInHooks = [
   './server/src/hooks/audit.js'
 ];


### PR DESCRIPTION
Switching `require('../../../foo')` to `require(__base + '/foo')`
- This is in reference to #179 - where refactoring with non-absolute imports was a PITA. I've tested this and it seems to work on my machine.
- Updated the changelog

![inline](http://rlv.zcache.com/works_on_my_machine_classic_round_sticker-r56ce1cc314be46efbe749e9c58c761d5_v9waf_8byvr_512.jpg)

cc @matteofigus @andyroyle @chriscartlidge etc
