### PR TITLE
Upgrading to Node LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10
+FROM node:6
 
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install -g grunt-cli && npm install bower -g && npm install

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "bugs": {
     "url": "https://github.com/opentable/hobknob/issues"
   },
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "dependencies": {
     "async": "^2.0.0-rc.6",
     "body-parser": "^1.14.0",


### PR DESCRIPTION
* Hopefully gets Hobknob running on the latest LTS...
* Installation works for me, though the test suite fails the same way for me with Node 0.10 and 6.x